### PR TITLE
Multiplicative noise and multiplicative noise with offset

### DIFF
--- a/src/aihwkit_lightning/nn/modules/torch_utils/torch_linear.py
+++ b/src/aihwkit_lightning/nn/modules/torch_utils/torch_linear.py
@@ -514,6 +514,19 @@ class TorchLinear:
             with no_grad():
                 noise = modifier.std_dev * assumed_wmax * randn_like(inp_weight)
             inp_weight = inp_weight + noise
+        elif modifier.type in [
+            WeightModifierType.MULTIPLICATIVE_OFFSET,
+            WeightModifierType.MULTIPLICATIVE_OFFSET_PER_CHANNEL,
+        ]:
+            with no_grad():
+                noise = (
+                    modifier.std_dev * inp_weight.abs() + assumed_wmax * modifier.offset
+                ) * randn_like(inp_weight)
+            inp_weight = inp_weight + noise
+        elif modifier.type == WeightModifierType.MULTIPLICATIVE:
+            with no_grad():
+                noise = modifier.std_dev * inp_weight.abs() * randn_like(inp_weight)
+            inp_weight = inp_weight + noise
         else:
             raise ConfigError(f"Weight modifier {modifier} not supported")
         return inp_weight

--- a/src/aihwkit_lightning/simulator/parameters/enums.py
+++ b/src/aihwkit_lightning/simulator/parameters/enums.py
@@ -35,6 +35,15 @@ class WeightModifierType(Enum):
     ADD_NORMAL_PER_CHANNEL = "AddNormalPerChannel"
     """Additive Gaussian noise per channel."""
 
+    MULTIPLICATIVE = "Multiplicative"
+    """Multiplicative noise."""
+
+    MULTIPLICATIVE_OFFSET = "MultiplicativeOffset"
+    """Multiplicative plus offset noise."""
+
+    MULTIPLICATIVE_OFFSET_PER_CHANNEL = "MultiplicativeOffsetPerChannel"
+    """Multiplicative plus offset noise per channel."""
+
     DISCRETIZE_ADD_NORMAL = "DiscretizeAddNormal"
     """First discretize and then additive Gaussian noise."""
 

--- a/src/aihwkit_lightning/simulator/parameters/inference.py
+++ b/src/aihwkit_lightning/simulator/parameters/inference.py
@@ -30,12 +30,13 @@ class WeightModifierParameter(_PrintableMixin):
 
     This parameter affects the modifier types ``AddNormal``, ``MultNormal`` and
     ``DiscretizeAddNormal``.
+    """
 
-    Note:
-        If the parameter ``rel_to_actual_wmax`` is set then the ``std_dev`` is
-        computed in relative terms to the abs max of the given weight matrix,
-        otherwise it in relative terms to the assumed max, which is set by
-        ``assumed_wmax``.
+    offset: float = 0.0
+    """Offset of the standard deviation of the noise.
+
+    This parameter affects the modifier types ``MultiplicativeOffset``, and
+    ``MultiplicativeOffsetPerChannel``.
     """
 
     res: float = 0.0


### PR DESCRIPTION
## Description

Adds support for multiplicative noise with and without an offset.

## Details

Three noise models:
- MULTIPLICATIVE: Scales std by the abs of the weights.
- MULTIPLICATIVE_OFFSET: Same but adds a constant offset (scaled by max-abs of weights)
- MULTIPLICATIVE_OFFSET_PER_CHANNEL: Same but adds a constant offset (scaled by max-abs of weights per channel)