### PR TITLE
Move to meta

### DIFF
--- a/src/aihwkit_lightning/nn/modules/base.py
+++ b/src/aihwkit_lightning/nn/modules/base.py
@@ -73,13 +73,13 @@ class AnalogLayerBase:
                 yield name, layer
 
     @classmethod
-    def move_to_meta(cls, _):
+    def move_to_meta(cls, module):
         """Move the module to the meta class.
 
         This is used to move the module to the meta class. This is
         useful for the conversion of the module to analog.
         """
-        return
+        module.to(device="meta")
 
     def clip_weights(self) -> None:
         """Clip the weights of the analog layers."""

--- a/src/aihwkit_lightning/nn/modules/base.py
+++ b/src/aihwkit_lightning/nn/modules/base.py
@@ -73,13 +73,13 @@ class AnalogLayerBase:
                 yield name, layer
 
     @classmethod
-    def move_to_meta(cls, module):
+    def move_to_meta(cls, _):
         """Move the module to the meta class.
 
         This is used to move the module to the meta class. This is
         useful for the conversion of the module to analog.
         """
-        module.to(device="meta")
+        return
 
     def clip_weights(self) -> None:
         """Clip the weights of the analog layers."""

--- a/src/aihwkit_lightning/nn/modules/conv.py
+++ b/src/aihwkit_lightning/nn/modules/conv.py
@@ -156,6 +156,19 @@ class _AnalogConvNd(AnalogLayerBase, _ConvNd):
         base, extra = divmod(size, n_splits)
         return [base + (i < extra) for i in range(n_splits)]
 
+    @classmethod
+    def move_to_meta(cls, module: _ConvNd):
+        """Move the module to the meta class.
+
+        This is used to move the module to the meta class. This is
+        useful for the conversion of the module to analog.
+
+        Args:
+            module: The module to move to the meta class.
+
+        """
+        module.to(device="meta")
+
     def set_weights(self, weight: Tensor) -> None:
         """Set the weight tensor to the analog crossbar. Creates a copy of the tensors.
 

--- a/src/aihwkit_lightning/nn/modules/conv.py
+++ b/src/aihwkit_lightning/nn/modules/conv.py
@@ -156,21 +156,6 @@ class _AnalogConvNd(AnalogLayerBase, _ConvNd):
         base, extra = divmod(size, n_splits)
         return [base + (i < extra) for i in range(n_splits)]
 
-    @classmethod
-    def move_to_meta(cls, module: _ConvNd):
-        """Move the module to the meta class.
-
-        This is used to move the module to the meta class. This is
-        useful for the conversion of the module to analog.
-
-        Args:
-            module: The module to move to the meta class.
-
-        """
-        module.weight.data = module.weight.data.to(device="meta")
-        if module.bias is not None:
-            module.bias.data = module.bias.data.to(device="meta")
-
     def set_weights(self, weight: Tensor) -> None:
         """Set the weight tensor to the analog crossbar. Creates a copy of the tensors.
 

--- a/src/aihwkit_lightning/nn/modules/linear.py
+++ b/src/aihwkit_lightning/nn/modules/linear.py
@@ -212,19 +212,6 @@ class AnalogLinear(Linear, AnalogLayerBase):
             digital_layer.bias.data = module.bias.data.detach().clone()
         return digital_layer.to(device=module.weight.device, dtype=module.weight.dtype)
 
-    @classmethod
-    def move_to_meta(cls, module: Linear):
-        """Move the module to the meta class.
-
-        This is used to move the module to the meta class. This is
-        useful for the conversion of the module to analog.
-
-        Args:
-            module: The module to move to the meta class.
-
-        """
-        module.to(device="meta")
-
     def set_weights(self, weight: Tensor) -> None:
         """Set the weight tensor to the analog crossbar. Creates a copy of the tensors.
 

--- a/src/aihwkit_lightning/nn/modules/linear.py
+++ b/src/aihwkit_lightning/nn/modules/linear.py
@@ -212,6 +212,19 @@ class AnalogLinear(Linear, AnalogLayerBase):
             digital_layer.bias.data = module.bias.data.detach().clone()
         return digital_layer.to(device=module.weight.device, dtype=module.weight.dtype)
 
+    @classmethod
+    def move_to_meta(cls, module: Linear):
+        """Move the module to the meta class.
+
+        This is used to move the module to the meta class. This is
+        useful for the conversion of the module to analog.
+
+        Args:
+            module: The module to move to the meta class.
+
+        """
+        module.to(device="meta")
+
     def set_weights(self, weight: Tensor) -> None:
         """Set the weight tensor to the analog crossbar. Creates a copy of the tensors.
 

--- a/src/aihwkit_lightning/nn/modules/linear.py
+++ b/src/aihwkit_lightning/nn/modules/linear.py
@@ -223,9 +223,7 @@ class AnalogLinear(Linear, AnalogLayerBase):
             module: The module to move to the meta class.
 
         """
-        module.weight.data = module.weight.data.to(device="meta")
-        if module.bias is not None:
-            module.bias.data = module.bias.data.to(device="meta")
+        module.to(device="meta")
 
     def set_weights(self, weight: Tensor) -> None:
         """Set the weight tensor to the analog crossbar. Creates a copy of the tensors.


### PR DESCRIPTION
## Description

Move move_to_meta up to `AnalogLayerBase`

## Details

This function can be implemented regardless of module identity and can therefore be moved to base layer.