### PR TITLE
Quantization of the weights can be performed explicitly after training

### DIFF
--- a/src/aihwkit_lightning/nn/modules/base.py
+++ b/src/aihwkit_lightning/nn/modules/base.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Base class for adding functionality to analog layers."""
+import warnings
 from typing import Tuple, Generator, Callable, List, Any
 from torch import dtype as torch_dtype
 from torch import device as torch_device
@@ -154,4 +155,6 @@ class AnalogLayerBase:
 
     def quantize_weights(self) -> None:
         """Quantize the weights in-place given the quantization type."""
+        warnings.warn("Modified the rpu_config because quantize_weights was called.")
         self.rpu_config.modifier.quantization_type = WeightQuantizationType.NONE
+        self.rpu_config.clip.type = WeightClipType.NONE

--- a/src/aihwkit_lightning/nn/modules/base.py
+++ b/src/aihwkit_lightning/nn/modules/base.py
@@ -17,7 +17,7 @@ from torch import device as torch_device
 from torch.nn import Parameter
 from torch import Tensor, empty, zeros
 from ...simulator.configs import TorchInferenceRPUConfig
-from ...simulator.parameters import WeightClipType
+from ...simulator.parameters import WeightClipType, WeightQuantizationType
 
 
 class AnalogLayerBase:
@@ -151,3 +151,7 @@ class AnalogLayerBase:
             self.input_range_update_idx = None
             self.x_min = None  # type: ignore
             self.x_max = None  # type: ignore
+
+    def quantize_weights(self) -> None:
+        """Quantize the weights in-place given the quantization type."""
+        self.rpu_config.modifier.quantization_type = WeightQuantizationType.NONE

--- a/src/aihwkit_lightning/nn/modules/container.py
+++ b/src/aihwkit_lightning/nn/modules/container.py
@@ -104,3 +104,8 @@ class AnalogWrapper(AnalogContainerBase):
         new_module = digital_class.__new__(digital_class)  # type: ignore
         new_module.__dict__ = module.__dict__
         return new_module
+
+    def quantize_weights(self):
+        """Iterate through analog layers in model and quantize weights in-place."""
+        for layer in self.analog_layers():
+            layer.quantize_weights()

--- a/src/aihwkit_lightning/nn/modules/conv.py
+++ b/src/aihwkit_lightning/nn/modules/conv.py
@@ -18,12 +18,13 @@ from typing import Optional, Tuple, Union, List
 import os
 from copy import deepcopy
 from functools import reduce
-from torch import Tensor, cuda, tensor, int32
+from torch import Tensor, cuda, no_grad, tensor, int32
 from torch.nn.functional import unfold
 from torch.nn.modules.conv import _ConvNd, Conv1d, Conv2d
 from torch.nn.modules.utils import _single, _pair
 
 from .base import AnalogLayerBase
+from .torch_utils.quant_utils import clip_and_quantize
 from .torch_utils.torch_abs_max import sliced_abs_max
 from .torch_utils.torch_linear import TorchLinear
 from ...simulator.configs import TorchInferenceRPUConfig, WeightClipType
@@ -195,6 +196,29 @@ class _AnalogConvNd(AnalogLayerBase, _ConvNd):
             tuple: weight matrix, bias vector
         """
         return (self.weight, self.bias)
+
+    @no_grad()
+    def quantize_weights(self) -> None:
+        """Quantize the weights."""
+        weight_2d = self.weight.view(self.out_channels, -1)
+        current_upper = 0
+        for slice_idx, inp_size in enumerate(self.in_sizes):
+            modified_slice = weight_2d[:, current_upper : current_upper + inp_size]
+            modified_slice = clip_and_quantize(
+                inp_weight=modified_slice,
+                assumed_wmax=None,
+                learnable_weight_clip=(
+                    None
+                    if self.learnable_weight_clip is None
+                    else self.learnable_weight_clip[slice_idx].unsqueeze(-1)
+                ),
+                rpu_config=self.rpu_config,
+            )
+            weight_2d[:, current_upper : current_upper + inp_size] = modified_slice
+            current_upper += inp_size
+
+        self.weight.data = weight_2d.view_as(self.weight)
+        super().quantize_weights()
 
     def forward(self, inp: Tensor) -> Tensor:
         """Compute the forward pass."""

--- a/src/aihwkit_lightning/nn/modules/torch_utils/quant_utils.py
+++ b/src/aihwkit_lightning/nn/modules/torch_utils/quant_utils.py
@@ -18,6 +18,12 @@ from torch import Tensor, finfo, clamp
 from torch import sum as torch_sum
 from torch.autograd import Function
 from torch.autograd.function import FunctionCtx
+from aihwkit_lightning.simulator.configs import (
+    TorchInferenceRPUConfig,
+    WeightQuantizationType,
+    WeightClipType,
+)
+from aihwkit_lightning.exceptions import ConfigError
 
 
 class UniformQuantize(Function):
@@ -148,3 +154,84 @@ class UniformQuantize(Function):
             grad_res = None
 
         return grad_input, grad_res, None, None, None, None, None
+
+
+def clip_and_quantize(
+    inp_weight: Tensor,
+    assumed_wmax: Union[Tensor, None],
+    learnable_weight_clip: Union[Tensor, None],
+    rpu_config: TorchInferenceRPUConfig,
+) -> Tensor:
+    """
+    Applies learned weight clipping ranges. This is only done if the weight modifier
+    is not one of the quantization weight modifiers.
+
+    Args:
+        inp_weight: Input weights.
+        assumed_wmax: Assumed maximum weight value.
+        learnable_weight_clip: The learnable per-column clipping values.
+        rpu_config: RPUConfig used.
+
+    Raises:
+        ConfigError: Unsupported/unknown weight modifier type.
+
+    Returns:
+        Clamped weights if clamping was applicable (not in place).
+    """
+    modifier = rpu_config.modifier
+
+    # 1, maybe clip
+    learnable_weight_clipping = rpu_config.clip.type == WeightClipType.LEARNABLE_PER_CHANNEL
+    if learnable_weight_clipping:
+        assert learnable_weight_clip is not None, "learnable_weight_clip should not be None"
+        assert learnable_weight_clip.shape == (
+            inp_weight.size(0),
+            1,
+        ), f"learnable_weight_clip.shape must be ({inp_weight.size(0)}, 1)"
+        if modifier.quantization_type == WeightQuantizationType.NONE:
+            # we pass the learned learnable_weight_clip
+            # we want to clip at -1 1 after "normalization"
+            # we want to skip rounding in this case
+            # we can do in place since we don't modify the weight
+            inp_weight = UniformQuantize.apply(
+                inp_weight, learnable_weight_clip, 0.5, False, learnable_weight_clipping, 1.0, True
+            )
+
+    # after we might have done clipping, return if we don't want to quantize
+    if modifier.quantization_type == WeightQuantizationType.NONE:
+        return inp_weight
+
+    # 2, if we're here, we definitely quantize
+    if assumed_wmax is None:
+        assumed_wmax = inp_weight.abs().amax(dim=1, keepdim=True)
+
+    if modifier.quantization_type in [
+        WeightQuantizationType.DISCRETIZE,
+        WeightQuantizationType.DISCRETIZE_PER_CHANNEL,
+    ]:
+        res = modifier.res
+        n_states = max(res, 1 / res)
+        max_quant_state = n_states / 2
+        if learnable_weight_clipping:
+            assert learnable_weight_clip is not None, "learnable_weight_clip should not be None"
+            scaling_factors = learnable_weight_clip / n_states  # type: ignore[assignment]
+        else:
+            if modifier.quantization_type == WeightQuantizationType.DISCRETIZE:
+                scaling_factors = assumed_wmax.max() / n_states
+            else:
+                scaling_factors = assumed_wmax / n_states  # type: ignore[assignment]
+
+        # Discretize the weights on the fly and backprob through them
+        inp_weight = UniformQuantize.apply(
+            inp_weight,
+            scaling_factors,
+            1.0,
+            False,
+            learnable_weight_clipping,
+            max_quant_state,
+            False,
+        )
+    else:
+        raise ConfigError(f"modifier.quantization_type {modifier.quantization_type} not supported")
+
+    return inp_weight

--- a/src/aihwkit_lightning/nn/modules/torch_utils/torch_linear.py
+++ b/src/aihwkit_lightning/nn/modules/torch_utils/torch_linear.py
@@ -221,17 +221,16 @@ class TorchLinear:
             else:
                 assumed_wmax = None
 
-            if training:
-                modified_slice = clip_and_quantize(
-                    inp_weight=modified_slice,
-                    assumed_wmax=assumed_wmax,
-                    learnable_weight_clip=(
-                        None
-                        if learnable_weight_clip is None
-                        else learnable_weight_clip[slice_idx].unsqueeze(-1)
-                    ),
-                    rpu_config=rpu_config,
-                )
+            modified_slice = clip_and_quantize(
+                inp_weight=modified_slice,
+                assumed_wmax=assumed_wmax,
+                learnable_weight_clip=(
+                    None
+                    if learnable_weight_clip is None
+                    else learnable_weight_clip[slice_idx].unsqueeze(-1)
+                ),
+                rpu_config=rpu_config,
+            )
             if rpu_config.clip.type == WeightClipType.LEARNABLE_PER_CHANNEL:
                 assert rpu_config.modifier.quantization_type in [
                     WeightQuantizationType.NONE,

--- a/tests/test_post_training_weight_quantization.py
+++ b/tests/test_post_training_weight_quantization.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2025 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=too-many-locals, too-many-public-methods, no-member
+"""Test for post-training weight quantization."""
+
+from unittest import SkipTest
+from pytest import mark
+from torch import Tensor, randn, allclose
+from torch.nn import Module, Linear, Conv1d, Conv2d
+from torch.optim import AdamW
+from aihwkit_lightning.nn.conversion import convert_to_analog
+from aihwkit_lightning.simulator.configs import (
+    TorchInferenceRPUConfig,
+    WeightQuantizationType,
+    WeightClipType,
+)
+from aihwkit_lightning.optim import AnalogOptimizer
+
+
+class WeightQuantTestModel(Module):
+    """Test model."""
+
+    def __init__(self):
+        super().__init__()
+        self.conv1 = Conv1d(in_channels=3, out_channels=3, kernel_size=3, padding=1)
+        self.conv2 = Conv2d(in_channels=3, out_channels=1024, kernel_size=3)
+        self.fc1 = Linear(1024, 512)
+        self.fc2 = Linear(512, 10)
+
+    def forward(self, x: Tensor):
+        """
+        Forward method
+
+        Args:
+            x (Tensor): Input.
+
+        Returns:
+            Tensor: Output.
+        """
+        x = self.conv1(x)
+        x = x.reshape(x.shape[0], x.shape[1], 10, 10)
+        x = self.conv2(x)
+        x = x.reshape(x.shape[0], -1, 1024)
+        x = self.fc1(x)
+        x = self.fc2(x)
+        return x
+
+
+@mark.parametrize(
+    "weight_quantization_type",
+    [
+        WeightQuantizationType.DISCRETIZE,
+        WeightQuantizationType.DISCRETIZE_PER_CHANNEL,
+        WeightQuantizationType.NONE,
+    ],
+)
+@mark.parametrize("num_weight_bits", [2, 4, 8])
+@mark.parametrize("max_input_size", [256, 512])
+@mark.parametrize(
+    "clip_type",
+    [
+        WeightClipType.LAYER_GAUSSIAN,
+        WeightClipType.LAYER_GAUSSIAN_PER_CHANNEL,
+        WeightClipType.LEARNABLE_PER_CHANNEL,
+        WeightClipType.NONE,
+    ],
+)
+def test_post_training_weight_quantization(
+    weight_quantization_type: WeightQuantizationType,
+    num_weight_bits: int,
+    max_input_size: int,
+    clip_type: WeightClipType,
+):
+    """Test loading the optimizer state and compare to torch"""
+
+    if clip_type != WeightClipType.NONE and weight_quantization_type != WeightQuantizationType.NONE:
+        if (
+            "CHANNEL" in str(clip_type)
+            and "CHANNEL" not in str(weight_quantization_type)
+            or "CHANNEL" not in str(clip_type)
+            and "CHANNEL" in str(weight_quantization_type)
+        ):
+            raise SkipTest("Cannot mix channel and tensor")
+
+    rpu_config = TorchInferenceRPUConfig()
+    rpu_config.modifier.quantization_type = weight_quantization_type
+    rpu_config.modifier.res = 2**num_weight_bits - 2  # 5 bits, from [-15, to 15]
+    rpu_config.mapping.max_input_size = max_input_size
+    rpu_config.clip.type = clip_type
+    rpu_config.clip.sigma = 2.0
+
+    inp = randn(2, 3, 100)
+
+    model = WeightQuantTestModel()
+
+    analog_model = convert_to_analog(model, rpu_config=rpu_config)
+
+    # create an analog optimizer
+    optim = AnalogOptimizer(
+        AdamW, analog_model.analog_layers(), analog_model.parameters(), lr=0.001
+    )
+    for _ in range(1):
+        optim.zero_grad()
+        out = analog_model(inp)
+        loss = out.sum()
+        loss.backward()
+        optim.step()
+
+    training_loss = analog_model(inp).sum()
+    analog_model.quantize_weights()
+    training_loss_quantized = analog_model(inp).sum()
+    analog_model.eval()
+    eval_loss_quantized = analog_model(inp).sum()
+
+    assert allclose(training_loss_quantized, eval_loss_quantized, atol=1e-5)
+    assert allclose(training_loss, training_loss_quantized, atol=1e-5)
+    assert allclose(training_loss, eval_loss_quantized, atol=1e-5)
+
+
+if __name__ == "__main__":
+    test_post_training_weight_quantization(
+        weight_quantization_type=WeightQuantizationType.DISCRETIZE_PER_CHANNEL,
+        num_weight_bits=4,
+        max_input_size=512,
+        clip_type=WeightClipType.NONE,
+    )


### PR DESCRIPTION
## Related issues

#22 

## Description
Before, weights were always quantized in the forward, which adds unnecessary extra FLOPS, would make it hard to exploit the low-bit nature of the weights, and makes it impossible to add weight noise outside of the network to test the effect of weight noise **on top of** already quantized weights. This PR makes this possible while still making sure that during evaluation during training, the quantized weights are used.