### PR TITLE
fix(pyproject.toml): update required Python version to 3.10 to solve …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 name = "aihwkit_lightning"
 version = "2.0.1"
 authors = [


### PR DESCRIPTION
…mistmatch deps

## Related issues
N/A
<!-- Link to the issues that are related to this pull request. -->

## Description
Black formatter new version was conflicting with the required minimal python version.
<!-- A short description of the changes included in the pull request. -->

## Details
To solve it we bump the required version of python from 3.8 to 3.10
<!-- A more elaborate description of the changes, if needed. -->